### PR TITLE
Alterada as keys do método getAmounts() para pegar o nome correto fornecido pelo XML

### DIFF
--- a/src/laravel/pagseguro/Transaction/Information/InformationFactory.php
+++ b/src/laravel/pagseguro/Transaction/Information/InformationFactory.php
@@ -144,11 +144,11 @@ class InformationFactory extends InformationAbstractFactory
     public function getAmounts()
     {
         $map = array_fill_keys([
-            'grossamount',
-            'discountamount',
-            'feeamount',
-            'netamount',
-            'extraamount',
+            'grossAmount',
+            'discountAmount',
+            'feeAmount',
+            'netAmount',
+            'extraAmount',
         ], null);
         $data = array_intersect_key($this->data, $map);
         $normalized = $this->normalizer->amountNormalized($data);


### PR DESCRIPTION
As propriedades do XML retornado seguem o padrão camelCase, porém essa alteração ainda não corrige o feeAmount