### PR TITLE
Fixed compatibility and notification without shipping problems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 vendor
 bin
+coverage
 composer.phar
 composer.lock
 .DS_Store

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "symfony/translation": "^3.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "5.*.*"
+        "phpunit/phpunit": "4.*.*"
     },
     "autoload": {
         "psr-0":{
@@ -36,6 +36,5 @@
     },
     "config":{
         "bin-dir": "bin/"
-    },
-    "minimum-stability": "dev"
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -10,10 +10,11 @@
         "lib-curl": "*",
         "lib-openssl": "*",
         "lib-libxml": "*",
-        "illuminate/validation": ">=4.2"
+        "illuminate/validation": ">=4.2",
+        "symfony/translation": "^3.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "4.0.*"
+        "phpunit/phpunit": "5.*.*"
     },
     "autoload": {
         "psr-0":{

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,7 @@
         "lib-curl": "*",
         "lib-openssl": "*",
         "lib-libxml": "*",
-        "illuminate/validation": ">=4.2",
-        "symfony/translation": "^3.3"
+        "illuminate/validation": ">=4.2"
     },
     "require-dev": {
         "phpunit/phpunit": "4.*.*"

--- a/src/laravel/pagseguro/Complements/DataHydratorTrait/DataHydratorTrait.php
+++ b/src/laravel/pagseguro/Complements/DataHydratorTrait/DataHydratorTrait.php
@@ -58,7 +58,9 @@ trait DataHydratorTrait
             $value = $itr->current();
             $method = 'set' . ucfirst($key);
             if (method_exists($this, $method)) {
-                $this->{$method}($value);
+                if (!empty($value)) {
+                    $this->{$method}($value);
+                }
             } else {
                 $this->{$key} = $value;
             }

--- a/src/laravel/pagseguro/Platform/Laravel5.php
+++ b/src/laravel/pagseguro/Platform/Laravel5.php
@@ -2,6 +2,8 @@
 
 namespace laravel\pagseguro\Platform;
 
+use Illuminate\Support\Facades\Input;
+
 /**
  * Platform Laravel
  *
@@ -21,7 +23,7 @@ class Laravel5 implements PlatformInterface
      */
     public function getUrlParameters()
     {
-        return \Input::all();
+        return Input::all();
     }
 
     /**

--- a/src/laravel/pagseguro/Transaction/Information/InformationFactory.php
+++ b/src/laravel/pagseguro/Transaction/Information/InformationFactory.php
@@ -62,7 +62,9 @@ class InformationFactory extends InformationAbstractFactory
         $data['paymentMethod'] = $this->getPaymentMethod();
         $data['amounts'] = $this->getAmounts();
         $data['sender'] = $this->getSender();
-        $data['shipping'] = $this->getShipping();
+        if (isset($this->data['shipping'])) {
+            $data['shipping'] = $this->getShipping();
+        }
         $data['items'] = $this->getItems();
         return new Information($data);
     }

--- a/tests/unit/ValidationRules.php
+++ b/tests/unit/ValidationRules.php
@@ -21,8 +21,15 @@ class ValidationRules extends \PHPUnit_Framework_TestCase
      */
     protected function validatorMake($rule, $value)
     {
+        // return new \Illuminate\Validation\Validator(
+        //     new \Symfony\Component\Translation\Translator('pt_BR'),
+        //     ['field' => $value],
+        //     ['field' => $rule]
+        // );
         return new \Illuminate\Validation\Validator(
-            new \Symfony\Component\Translation\Translator('pt_BR'),
+            new \Illuminate\Translation\Translator(
+                new \Illuminate\Translation\ArrayLoader, 'pt_BR'
+            ),
             ['field' => $value],
             ['field' => $rule]
         );


### PR DESCRIPTION
**Test:** Received a PagSeguro notification

**Error:** on Laravel5.php - Line 26. Class Input not found

The the commit https://github.com/laravel/laravel/commit/2adbbbd91e9d6e2d569cc56f138b7273efe25651 removed the `Input` Facade.

**Possible solution:**

We can import `Input` facade directly as required (recomended),

```php
use Illuminate\Support\Facades\Input;
```

**Test:** Received a PagSeguro notification in transaction opened without `shipping`. On request to PagSeguro passed:
```xml
<shipping>
    <addressRequired>false</addressRequired>
</shipping>
```

**Error:** ErrorException in InformationFactory.php line 182: Undefined index: shipping

**Possible solution:**

1 - Check if `$this->data` has `shipping` index before call the method `$this->getShipping()` on `laravel\pagseguro\Transaction\Information\InformationFactory.php` line 65;

```php
if (isset($this->data['shipping'])) {
    $data['shipping'] = $this->getShipping();
}
```

2 - Check if `$value` that will be passed to `$this->setShipping()` function is not empty on `laravel\pagseguro\Complements\DataHydratorTrait\DataHydratorTrait` line 61 

```php
if (!empty($value)) {
    $this->{$method}($value);
}
```
