### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "illuminate/validation": ">=4.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "4.*.*"
+        "phpunit/phpunit": "^4.8.35"
     },
     "autoload": {
         "psr-0":{

--- a/tests/unit/Address/AddressTest.php
+++ b/tests/unit/Address/AddressTest.php
@@ -3,12 +3,13 @@
 namespace laravel\pagseguro\Tests\Unit\Address;
 
 use laravel\pagseguro\Address\Address;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Address Test
  * @author Isaque de Souza <isaquesb@gmail.com>
  */
-class AddressTest extends \PHPUnit_Framework_TestCase
+class AddressTest extends TestCase
 {
 
     public function testEmptyAddress()

--- a/tests/unit/Checkout/CheckoutBase.php
+++ b/tests/unit/Checkout/CheckoutBase.php
@@ -4,12 +4,13 @@ namespace laravel\pagseguro\Tests\Unit\Checkout;
 
 use laravel\pagseguro\Checkout\SimpleCheckout;
 use laravel\pagseguro\Facades\Checkout;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Checkout Test Base
  * @author Isaque de Souza <isaquesb@gmail.com>
  */
-class CheckoutBase extends \PHPUnit_Framework_TestCase
+class CheckoutBase extends TestCase
 {
     /**
      * @var SimpleCheckout

--- a/tests/unit/Credentials/CredentialsTest.php
+++ b/tests/unit/Credentials/CredentialsTest.php
@@ -3,12 +3,13 @@
 namespace laravel\pagseguro\Tests\Unit\Credentials;
 
 use laravel\pagseguro\Credentials\Credentials;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Credentials Test
  * @author     Michael Douglas <michaeldouglas010790@gmail.com>
  */
-class CredentialsTest extends \PHPUnit_Framework_TestCase
+class CredentialsTest extends TestCase
 {
 
     /**
@@ -50,43 +51,43 @@ class CredentialsTest extends \PHPUnit_Framework_TestCase
     {
         new Credentials('651233CECD6304779B7570BA2D06', null);
     }
-    
+
     public function testShouldReturnAgivenToken()
     {
         $credentials = new Credentials(
-                '651233CECD6304779B7570BA2D06', 
+                '651233CECD6304779B7570BA2D06',
                 'michaeldouglas010790@gmail.com'
         );
         $this->assertEquals('651233CECD6304779B7570BA2D06', $credentials->getToken());
     }
-    
+
     public function testShouldReturnAgivenEmail()
     {
         $credentials = new Credentials(
-                '651233CECD6304779B7570BA2D06', 
+                '651233CECD6304779B7570BA2D06',
                 'michaeldouglas010790@gmail.com'
         );
         $this->assertEquals('michaeldouglas010790@gmail.com', $credentials->getEmail());
     }
-    
+
     public function testShouldValidateCredentials()
     {
         $credentials = new Credentials(
-                '651233CECD6304779B7570BA2D06', 
+                '651233CECD6304779B7570BA2D06',
                 'michaeldouglas010790@gmail.com'
         );
         $this->assertTrue($credentials->isValid());
     }
-    
+
     public function testShouldReturnAnArrayWithAgivenCredential()
     {
         $credentials = new Credentials(
-                '651233CECD6304779B7570BA2D06', 
+                '651233CECD6304779B7570BA2D06',
                 'michaeldouglas010790@gmail.com'
         );
-        
+
         $array = $credentials->toArray();
-        
+
         $this->assertEquals('651233CECD6304779B7570BA2D06', $array['token']);
         $this->assertEquals('michaeldouglas010790@gmail.com', $array['email']);
     }

--- a/tests/unit/Document/CPF/CPFTest.php
+++ b/tests/unit/Document/CPF/CPFTest.php
@@ -3,12 +3,13 @@
 namespace laravel\pagseguro\Tests\Unit\Sender\Document\CPF;
 
 use laravel\pagseguro\Document\CPF\CPF;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Sender Document CPF Test
  * @author Isaque de Souza <isaquesb@gmail.com>
  */
-class CPFTest extends \PHPUnit_Framework_TestCase
+class CPFTest extends TestCase
 {
 
     public function testEmptyCPF()

--- a/tests/unit/Document/DocumentCollectionTest.php
+++ b/tests/unit/Document/DocumentCollectionTest.php
@@ -4,12 +4,13 @@ namespace laravel\pagseguro\Tests\Unit\Sender\Document;
 
 use laravel\pagseguro\Document\CPF\CPF;
 use laravel\pagseguro\Document\DocumentCollection;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Document Collection Test
  * @author Isaque de Souza <isaquesb@gmail.com>
  */
-class DocumentCollectionTest extends \PHPUnit_Framework_TestCase
+class DocumentCollectionTest extends TestCase
 {
 
     /**

--- a/tests/unit/Item/ItemCollectionTest.php
+++ b/tests/unit/Item/ItemCollectionTest.php
@@ -4,12 +4,13 @@ namespace laravel\pagseguro\Tests\Unit\Item;
 
 use laravel\pagseguro\Item\Item;
 use laravel\pagseguro\Item\ItemCollection;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Item Collection Test
  * @author Isaque de Souza <isaquesb@gmail.com>
  */
-class ItemCollectionTest extends \PHPUnit_Framework_TestCase
+class ItemCollectionTest extends TestCase
 {
 
     /**

--- a/tests/unit/Item/ItemTest.php
+++ b/tests/unit/Item/ItemTest.php
@@ -3,12 +3,13 @@
 namespace laravel\pagseguro\Tests\Unit\Item;
 
 use laravel\pagseguro\Item\Item;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Item Test
  * @author Isaque de Souza <isaquesb@gmail.com>
  */
-class ItemTest extends \PHPUnit_Framework_TestCase
+class ItemTest extends TestCase
 {
 
     public function testEmptyItem()

--- a/tests/unit/Notification/NotificationTest.php
+++ b/tests/unit/Notification/NotificationTest.php
@@ -3,12 +3,13 @@
 namespace laravel\pagseguro\Tests\Unit\Notification;
 
 use laravel\pagseguro\Notification\Notification;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Notification Test
  * @author Isaque de Souza <isaquesb@gmail.com>
  */
-class NotificationTest extends \PHPUnit_Framework_TestCase
+class NotificationTest extends TestCase
 {
 
     public function testEmptyNotification()

--- a/tests/unit/Parser/XmlTest.php
+++ b/tests/unit/Parser/XmlTest.php
@@ -3,12 +3,13 @@
 namespace laravel\pagseguro\Tests\Unit\Parser;
 
 use laravel\pagseguro\Parser\Xml;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Xml Test
  * @author Isaque de Souza <isaquesb@gmail.com>
  */
-class XmlTest extends \PHPUnit_Framework_TestCase
+class XmlTest extends TestCase
 {
 
     protected function getXmlForParseTest()

--- a/tests/unit/Payment/Method/FactoryTest.php
+++ b/tests/unit/Payment/Method/FactoryTest.php
@@ -9,12 +9,13 @@ use laravel\pagseguro\Payment\Method\CreditCard\CreditCardInterface;
 use laravel\pagseguro\Payment\Method\DepositAccount\DepositAccountInterface;
 use laravel\pagseguro\Payment\Method\Extras\ExtrasInterface;
 use laravel\pagseguro\Payment\Method\Transfer\TransferInterface;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Payment Method Factory Test
  * @author Isaque de Souza <isaquesb@gmail.com>
  */
-class NotificationTest extends \PHPUnit_Framework_TestCase
+class NotificationTest extends TestCase
 {
 
     /**

--- a/tests/unit/Phone/PhoneTest.php
+++ b/tests/unit/Phone/PhoneTest.php
@@ -3,12 +3,13 @@
 namespace laravel\pagseguro\Tests\Unit\Phone;
 
 use laravel\pagseguro\Phone\Phone;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Phone Test
  * @author Isaque de Souza <isaquesb@gmail.com>
  */
-class PhoneTest extends \PHPUnit_Framework_TestCase
+class PhoneTest extends TestCase
 {
 
     public function testStdPhone()

--- a/tests/unit/Sender/SenderTest.php
+++ b/tests/unit/Sender/SenderTest.php
@@ -3,12 +3,13 @@
 namespace laravel\pagseguro\Tests\Unit\Sender;
 
 use laravel\pagseguro\Sender\Sender;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Sender Test
  * @author Isaque de Souza <isaquesb@gmail.com>
  */
-class SenderTest extends \PHPUnit_Framework_TestCase
+class SenderTest extends TestCase
 {
 
     public function testEmptySender()

--- a/tests/unit/Shipping/ShippingTest.php
+++ b/tests/unit/Shipping/ShippingTest.php
@@ -4,12 +4,13 @@ namespace laravel\pagseguro\Tests\Unit\Shipping;
 
 use laravel\pagseguro\Shipping\Shipping;
 use laravel\pagseguro\Address\Address;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Shipping Test
  * @author Isaque de Souza <isaquesb@gmail.com>
  */
-class ShippingTest extends \PHPUnit_Framework_TestCase
+class ShippingTest extends TestCase
 {
 
     public function testEmptySender()

--- a/tests/unit/Transaction/Information/InformationTest.php
+++ b/tests/unit/Transaction/Information/InformationTest.php
@@ -10,12 +10,13 @@ use laravel\pagseguro\Transaction\Information;
 use laravel\pagseguro\Http\Response\Response;
 use laravel\pagseguro\Remote\Manager;
 use laravel\pagseguro\Transaction\Status\Status;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Information Factory Test
  * @author Isaque de Souza <isaquesb@gmail.com>
  */
-class InformationTest extends \PHPUnit_Framework_TestCase
+class InformationTest extends TestCase
 {
 
     /**

--- a/tests/unit/Transaction/StatusTest.php
+++ b/tests/unit/Transaction/StatusTest.php
@@ -3,12 +3,13 @@
 namespace laravel\pagseguro\Tests\Unit\Transaction;
 
 use laravel\pagseguro\Transaction\Status\Status;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Status Test
  * @author Isaque de Souza <isaquesb@gmail.com>
  */
-class StatusTest extends \PHPUnit_Framework_TestCase
+class StatusTest extends TestCase
 {
 
     /**

--- a/tests/unit/Transaction/TransactionTest.php
+++ b/tests/unit/Transaction/TransactionTest.php
@@ -4,12 +4,13 @@ namespace laravel\pagseguro\Tests\Unit\Transaction;
 
 use laravel\pagseguro\Transaction\Transaction;
 use laravel\pagseguro\Credentials\Credentials;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Transaction Test
  * @author Isaque de Souza <isaquesb@gmail.com>
  */
-class TransactionTest extends \PHPUnit_Framework_TestCase
+class TransactionTest extends TestCase
 {
 
     /**

--- a/tests/unit/ValidationRules.php
+++ b/tests/unit/ValidationRules.php
@@ -2,11 +2,13 @@
 
 namespace laravel\pagseguro\Tests\Unit;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * ValidationRules Test
  * @author Isaque de Souza <isaquesb@gmail.com>
  */
-class ValidationRules extends \PHPUnit_Framework_TestCase
+class ValidationRules extends TestCase
 {
 
     /**


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`^4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06), that support this namespace.