### PR TITLE
Telefone nulo

### DIFF
--- a/src/laravel/pagseguro/Sender/Sender.php
+++ b/src/laravel/pagseguro/Sender/Sender.php
@@ -137,11 +137,15 @@ class Sender implements SenderInterface
 
     /**
      * Set Phone (Telefone)
-     * @param PhoneInterface|array $phone
+     * @param PhoneInterface|array|null $phone
      * @return AddressInterface
      */
     public function setPhone($phone)
     {
+        if ($phone === null) {
+            $phone = [];
+        }
+
         $this->phone = new Phone($phone);
         return $this;
     }

--- a/tests/unit/Sender/SenderTest.php
+++ b/tests/unit/Sender/SenderTest.php
@@ -40,6 +40,19 @@ class SenderTest extends TestCase
         $this->assertInstanceOf($class, $sender->getPhone());
     }
 
+    public function testSenderWithoutPhonesKey()
+    {
+        $class = '\\laravel\\pagseguro\\Phone\\Phone';
+        $data = [
+            'email' => 'isaquesb@gmail.com',
+            'name' => 'Isaque de Souza',
+            'documents' => null,
+            'bornDate' => '1988-03-21',
+        ];
+        $sender = new Sender($data);
+        $this->assertInstanceOf($class, $sender->getPhone());
+    }
+
     public function testSenderWithoutDocuments()
     {
         $phone = new Phone([]);


### PR DESCRIPTION
Olá, durante alguns dos fluxos, nem todos os dados são fornecidos pelo Cliente/Pagseguro, como é o caso do telefone, documentos.

Por exemplo, no caso de notificação, onde apenas é retornado o email.
![1](https://user-images.githubusercontent.com/1251151/67683233-c8610b80-f96f-11e9-9c67-b253ca4390ee.png)



Isso causa um problema quando os dados são hidratados e são definidos valores nulos para os campos não retornados já que o campo de telefone requer um array.
![2](https://user-images.githubusercontent.com/1251151/67683523-4de4bb80-f970-11e9-818b-9c21197f9510.png)


![3](https://user-images.githubusercontent.com/1251151/67683659-7f5d8700-f970-11e9-9f03-a3c6221a171f.png)


Essa PR adiciona corrige o problema e adiciona um teste para evitar code regression no futuro.

Refs: 
    https://github.com/michaeldouglas/laravel-pagseguro/issues/143
    https://github.com/michaeldouglas/laravel-pagseguro/pull/141
