### PR TITLE
Correção telefone nulo

### DIFF
--- a/src/laravel/pagseguro/Sender/Sender.php
+++ b/src/laravel/pagseguro/Sender/Sender.php
@@ -143,7 +143,8 @@ class Sender implements SenderInterface
     public function setPhone($phone)
     {
         if ($phone === null) {
-            $phone = [];
+            $this->phone = null;
+            return $this;
         }
 
         $this->phone = new Phone($phone);


### PR DESCRIPTION
Mesmo depois do merge #150 eu ainda obtive o erro de telefone nulo.
Segue o erro abaixo:
Error on send: 400-<?xml version="1.0" encoding="ISO-8859-1" standalone="yes"?><errors><error><code>11013</code><message>senderAreaCode invalid value: {0}</message></error><error><code>11014</code><message>senderPhone invalid value: {0}</message></error></errors>
Aqui está a correção para isso.