### PR TITLE
Corrigindo problema de enviar com telefone vazio.

### DIFF
--- a/src/laravel/pagseguro/Sender/Sender.php
+++ b/src/laravel/pagseguro/Sender/Sender.php
@@ -144,9 +144,9 @@ class Sender implements SenderInterface
     {
         if ($phone === null) {
             $phone = [];
+        } else {
+            $this->phone = new Phone($phone);
         }
-
-        $this->phone = new Phone($phone);
         return $this;
     }
 


### PR DESCRIPTION
Quando entra `new Phone([]);` é construído com erro, que não é aceito pelo pagSeguro.