### PR TITLE
Notificações de Pagamento do Pagseguro com Credenciais Dinâmicas

### DIFF
--- a/src/laravel/pagseguro/Platform/Laravel5/NotificationController.php
+++ b/src/laravel/pagseguro/Platform/Laravel5/NotificationController.php
@@ -32,10 +32,7 @@ class NotificationController extends Controller
             $platform->abort();
             return;
         }
-        $credential = new PagSeguroCredentials(
-            \config('laravelpagseguro.credentials.token'),
-            \config('laravelpagseguro.credentials.email')
-        );
+        $credential = $this->getCredentialsTo($code);
         $notification = new Notification($code, $type);
         $info = $notification->check($credential);
         $this->notify($info);
@@ -74,7 +71,7 @@ class NotificationController extends Controller
             $callback = $config['credential'];
         }
         
-        if ($callback === 'default') {
+        if ($callback === 'default' || is_null($callback)) {
             return new PagSeguroCredentials(
                 \config('laravelpagseguro.credentials.token'),
                 \config('laravelpagseguro.credentials.email')


### PR DESCRIPTION
 Esse MR modifica a classe responsável pelo recebimento de notificações de pagamento do Pagseguro. O objetivo é reativar uma funcionalidade previamente documentada que permite a resolução dinâmica de credenciais. Essa funcionalidade é especialmente útil para sistemas de MarketPlace, onde diferentes lojas podem estar cadastradas e cada uma pode necessitar de credenciais diferentes.